### PR TITLE
BUG: Fix path assembly for SlicerSOFA

### DIFF
--- a/SlicerSofa/SofaEnvironment/__init__.py
+++ b/SlicerSofa/SofaEnvironment/__init__.py
@@ -8,8 +8,11 @@ if os.path.isdir(script_dir + '/../../../../../Sofa-build'): # Build tree
 else: # Install tree
     # Sofa does not allow much configurability of the install tree, therefore it is needed
     # to add extra python paths.
-    sys.path.append(script_dir + '/../../../../plugins/SofaPython3/lib/python3/site-packages')
-    sys.path.append(script_dir + '/../../../../plugins/STLIB/lib/python3/site-packages')
+    sys.path = [
+        script_dir + '/../../../../plugins/SofaPython3/lib/python3/site-packages',
+        script_dir + '/../../../../plugins/STLIB/lib/python3/site-packages'
+    ] + sys.path
+
     os.environ['SOFA_ROOT'] = script_dir + '/../../../../'
 
 # Sofa, by default, will capture the exception handling. This is a workaround


### PR DESCRIPTION
When loading SlicerSOFA on systems where a previous installation of SOFA is present, the paht set by the installed SOFA interferes with loading the SOFA library loade by SlicerSOFA. This commits changes the path assembly to prepend SlicerSOFA paths instead of append them.