### PR TITLE
Fix/mac os packaging/dylib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,6 @@ else() # APPLE
   install(DIRECTORY "${Sofa_DIR}/lib/"
     DESTINATION "${Slicer_INSTALL_THIRDPARTY_LIB_DIR}/"
     COMPONENT RuntimeLibraries
-    PATTERN "*.dylib" EXCLUDE
     PATTERN "cmake" EXCLUDE
     PATTERN "metis.framework" EXCLUDE
     PATTERN "plugin_list.conf.default" EXCLUDE
@@ -66,6 +65,7 @@ else() # APPLE
   #-----------------------------------------------------------------------------
   # Fixup candidates patterns specified as relative paths
   set(EXTENSION_FIXUP_BUNDLE_CANDIDATES_PATTERNS
+    "${Slicer_INSTALL_THIRDPARTY_LIB_DIR}/*.dylib" # Recursively SOFA libraries as these are plugins loaded in runtime
     "${Slicer_INSTALL_THIRDPARTY_LIB_DIR}/python3/site-packages/*.cpython-*.so" # Recursively glob Python modules
   )
   set(${EXTENSION_NAME}_FIXUP_BUNDLE_CANDIDATES_PATTERNS "${EXTENSION_FIXUP_BUNDLE_CANDIDATES_PATTERNS}" CACHE STRING "List of candidate patterns for globbing libraries that should be fixed up" FORCE)


### PR DESCRIPTION
@jcfr, it seems that not all SOFA libraries are handled by the linker in link-time. For the context I refer to our discussion where I thought that the entry point was `import Sofa` from python.  There are also plugins imported at runtime explicitly. 

In this PR I propose to install all the `*.dylib` files and add them to the fix pattern. I have tested this on my system and seems to work fine. I have checked some RPATH randomly and they seem to be in `@rpath/Extension-....` form, instead of absolute paths on my system, which makes me think that this will work.  